### PR TITLE
fixed return type RdKafka\ConsumerTopic::consume()

### DIFF
--- a/rdkafka/RdKafka/ConsumerTopic.php
+++ b/rdkafka/RdKafka/ConsumerTopic.php
@@ -10,7 +10,7 @@ class ConsumerTopic extends Topic
      * @param int $partition
      * @param int $timeout_ms
      *
-     * @return Message
+     * @return Message|null
      */
     public function consume($partition, $timeout_ms) {}
 


### PR DESCRIPTION
rd-kafka library implements RdKafka\ConsumerTopic::consume() method as do consume till Kafka service return value is not empty. Need to update return type.